### PR TITLE
Java11, User Entry, Press Enter to Continue

### DIFF
--- a/src/edu/ucalgary/ensf409/DatabaseIO.java
+++ b/src/edu/ucalgary/ensf409/DatabaseIO.java
@@ -111,7 +111,13 @@ public class DatabaseIO {
             this.dbConnect = DriverManager.getConnection(this.dbUrl,
                     this.username, this.password);
         } catch (SQLException e){
-            System.out.println("Unable to create a connection.");
+            System.out.println();
+            System.out.println("Unable to create a connection with");
+            System.out.println("the current credentials: ");
+            System.out.println("     DbURL: " + this.dbUrl);
+            System.out.println("  Username: " + this.username);
+            System.out.println("  Password: " + this.password);
+            System.out.println();
             e.printStackTrace();
         }
     }

--- a/src/edu/ucalgary/ensf409/Main.java
+++ b/src/edu/ucalgary/ensf409/Main.java
@@ -28,24 +28,27 @@ public class Main {
      * Main method for the program. Uses an infinite loop for calling
      * the UserIO input menu method, which provides interaction with
      * the user.
-     * Infinite loop will be stopped if the user makes the appropriate
-     * selection in the menu, where the program will end sucessfully.
+     * Loop will continue to run until the user opts to end the program
+     * through a selection in the menu, after which the main method will
+     * end the program.
      *
      * @param args Unused inputs from the command line when program
      *             is executed.
      */
     public static void main(String[] args) {
+        boolean continueLoop = true;
         UserIO input = new UserIO();
+        input.firstMenu();
         int selection = input.menu();
-        while(true) {                   // Runs in an infinite loop until
-                                        // input.processInput(selection)
-                                        // receives a value of selection = 0
-                                        // After all streams are closed
-                                        // and the program is terminated
-                                        // as expected (termination code 0)
-            input.processInput(selection);
+        continueLoop = input.processInput(selection);
+        while(continueLoop) { // Will continue to run the program through
+                                // the UserIO menu until the user opts to end
+                                // the program and continueLoop is set as false.
             selection = input.menu();
+            continueLoop = input.processInput(selection);
+
         }
+        System.exit(0);
 
     }
 }

--- a/src/edu/ucalgary/ensf409/Main.java
+++ b/src/edu/ucalgary/ensf409/Main.java
@@ -37,7 +37,12 @@ public class Main {
     public static void main(String[] args) {
         UserIO input = new UserIO();
         int selection = input.menu();
-        while(true) {
+        while(true) {                   // Runs in an infinite loop until
+                                        // input.processInput(selection)
+                                        // receives a value of selection = 0
+                                        // After all streams are closed
+                                        // and the program is terminated
+                                        // as expected (termination code 0)
             input.processInput(selection);
             selection = input.menu();
         }

--- a/src/edu/ucalgary/ensf409/SupplyChainTest.java
+++ b/src/edu/ucalgary/ensf409/SupplyChainTest.java
@@ -30,8 +30,8 @@ import static org.junit.Assert.assertFalse;
 
 
 /**
- * Class SupplyChainTest provides Junit 4 tests for the program to ensure the
- * correct outputs and results are produced by the program methods.
+ * Class SupplyChainTest provides Junit 4 tests for Supply Chain Manager to ensure the
+ * correct outputs and results are produced by Supply Chain Manager methods.
  */
 public class SupplyChainTest {
     private final ByteArrayOutputStream terminalContent
@@ -605,14 +605,11 @@ public class SupplyChainTest {
     @Test
     public void testUserIO_validOrderReadFurnCategory() {
         ByteArrayInputStream terminalInput1 = new ByteArrayInputStream(
-                ("1\n" +
-                 "Mesh chair, 1\n").getBytes());
+                ("\nMesh chair, 1\n" + "\n").getBytes());
         System.setIn(terminalInput1);
         UserIO userIO = new UserIO();
 
-        int readFromInput = userIO.menu();
-        System.setIn(terminalInput1);
-        userIO.processInput(readFromInput);
+        userIO.processInput(1);
 
         assertEquals("chair", userIO.getFurnCategory());
     }
@@ -626,14 +623,12 @@ public class SupplyChainTest {
     @Test
     public void testUserIO_validOrderReadFurnType() {
         ByteArrayInputStream terminalInput1 =
-                new ByteArrayInputStream(("1\n" +
+                new ByteArrayInputStream(("\n" +
                                           "Mesh chair, 1\n").getBytes());
         System.setIn(terminalInput1);
         UserIO userIO = new UserIO();
 
-        int readFromInput = userIO.menu();
-        System.setIn(terminalInput1);
-        userIO.processInput(readFromInput);
+        userIO.processInput(1);
 
         assertEquals("Mesh", userIO.getFurnType());
     }
@@ -647,14 +642,12 @@ public class SupplyChainTest {
     @Test
     public void testUserIO_validOrderReadNumOfItems() {
         ByteArrayInputStream terminalInput1 =
-                new ByteArrayInputStream(("1\n" +
+                new ByteArrayInputStream(("\n" +
                                           "Mesh chair, 1\n").getBytes());
         System.setIn(terminalInput1);
         UserIO userIO = new UserIO();
 
-        int readFromInput = userIO.menu();
-        System.setIn(terminalInput1);
-        userIO.processInput(readFromInput);
+        userIO.processInput(1);
 
         assertEquals("1", userIO.getNumOfItems());
     }
@@ -668,14 +661,12 @@ public class SupplyChainTest {
     @Test
     public void testUserIO_validOrderRequest() {
         ByteArrayInputStream terminalInput1 =
-                new ByteArrayInputStream(("1\n" +
+                new ByteArrayInputStream(("\n" +
                                           "Mesh chair, 1\n").getBytes());
         System.setIn(terminalInput1);
         UserIO userIO = new UserIO();
 
-        int readFromInput = userIO.menu();
-        System.setIn(terminalInput1);
-        userIO.processInput(readFromInput);
+        userIO.processInput(1);
 
         assertEquals("Mesh chair, 1", userIO.getLatestRequest());
     }
@@ -687,15 +678,13 @@ public class SupplyChainTest {
      */
     @Test public void testUserIO_invalidOrderReadFurnTypeFirstOrder(){
         ByteArrayInputStream terminalInput1 =
-                new ByteArrayInputStream(("1\n" +
+                new ByteArrayInputStream(("\n" +
                                           "Invalid input\n" +
                                           "CANCEL\n").getBytes());
         System.setIn(terminalInput1);
         UserIO userIO = new UserIO();
 
-        int readFromInput = userIO.menu();
-        System.setIn(terminalInput1);
-        userIO.processInput(readFromInput);
+        userIO.processInput(1);
 
         assertNull(userIO.getFurnType());
     }
@@ -707,26 +696,22 @@ public class SupplyChainTest {
      */
     @Test public void testUserIO_invalidOrderReadFurnTypeAfterFirst(){
         ByteArrayInputStream terminalInput1 =
-                new ByteArrayInputStream(("1\n" +
+                new ByteArrayInputStream(("\n" +
                                           "Mesh chair, 1\n" +
-                                          "1\n" +
+                                          "\n" +
                                           "Desk lamp, 1\n" +
-                                          "1\n" +
+                                          "\n" +
                                           "Invalid order name\n" +
                                           "CANCEL\n").getBytes());
         System.setIn(terminalInput1);
         UserIO userIO = new UserIO();
 
-        int readFromInput = userIO.menu();
-        System.setIn(terminalInput1); // Fulfills valid order "Mesh chair, 1"
-        userIO.processInput(readFromInput);
+        userIO.processInput(1); // Fulfills valid order "Mesh chair, 1"
 
-        readFromInput = userIO.menu();
-        userIO.processInput(readFromInput); // Fulfills the valid order
+        userIO.processInput(1); // Fulfills the valid order
                                             // "Desk lamp, 1"
 
-        readFromInput = userIO.menu();
-        userIO.processInput(readFromInput); // Attempts to fulfill the invalid
+        userIO.processInput(1); // Attempts to fulfill the invalid
                                             // order "Invalid order name"
 
 
@@ -740,15 +725,13 @@ public class SupplyChainTest {
      */
     @Test public void testUserIO_invalidOrderReadCategoryFirstOrder(){
         ByteArrayInputStream terminalInput1 =
-                new ByteArrayInputStream(("1\n" +
+                new ByteArrayInputStream(("\n" +
                                           "Invalid input\n" +
                                           "CANCEL\n").getBytes());
         System.setIn(terminalInput1);
         UserIO userIO = new UserIO();
 
-        int readFromInput = userIO.menu();
-        System.setIn(terminalInput1);
-        userIO.processInput(readFromInput);
+        userIO.processInput(1);
 
         assertNull(userIO.getFurnCategory());
     }
@@ -760,26 +743,23 @@ public class SupplyChainTest {
      */
     @Test public void testUserIO_invalidOrderReadFurnCategoryAfterFirst(){
         ByteArrayInputStream terminalInput1 =
-                new ByteArrayInputStream(("1\n" +
+                new ByteArrayInputStream(("\n" +
                                           "Mesh chair, 1\n" +
-                                          "1\n" +
+                                          "\n" +
                                           "Desk lamp, 1\n" +
-                                          "1\n" +
+                                          "\n" +
                                           "Invalid order\n" +
                                           "CANCEL\n").getBytes());
         System.setIn(terminalInput1);
         UserIO userIO = new UserIO();
 
-        int readFromInput = userIO.menu();
-        System.setIn(terminalInput1); // Fulfills valid order "Mesh chair, 1"
-        userIO.processInput(readFromInput);
+  System.setIn(terminalInput1); // Fulfills valid order "Mesh chair, 1"
+        userIO.processInput(1);
 
-        readFromInput = userIO.menu();
-        userIO.processInput(readFromInput); // Fulfills the valid order
+       userIO.processInput(1); // Fulfills the valid order
         // "Desk lamp, 1"
 
-        readFromInput = userIO.menu();
-        userIO.processInput(readFromInput); // Attempts to fulfill the invalid
+       userIO.processInput(1); // Attempts to fulfill the invalid
         // order "Invalid order"
 
 
@@ -793,15 +773,13 @@ public class SupplyChainTest {
      */
     @Test public void testUserIO_invalidOrderReadNumOfItemsFirstOrder(){
         ByteArrayInputStream terminalInput1 =
-                new ByteArrayInputStream(("1\n" +
+                new ByteArrayInputStream(("\n" +
                                           "Bad order\n" +
                                           "CANCEL\n").getBytes());
         System.setIn(terminalInput1);
         UserIO userIO = new UserIO();
 
-        int readFromInput = userIO.menu();
-        System.setIn(terminalInput1);
-        userIO.processInput(readFromInput);
+        userIO.processInput(1);
 
         assertNull(userIO.getNumOfItems());
     }
@@ -813,26 +791,23 @@ public class SupplyChainTest {
      */
     @Test public void testUserIO_invalidOrderReadNumOfItemsAfterFirst(){
         ByteArrayInputStream terminalInput1 =
-                new ByteArrayInputStream(("1\n" +
+                new ByteArrayInputStream(("\n" +
                                           "Mesh chair, 1\n" +
-                                          "1\n" +
+                                          "\n" +
                                           "Desk lamp, 1\n" +
-                                          "1\n" +
+                                          "\n" +
                                           "Meaningless order\n" +
                                           "CANCEL\n").getBytes());
         System.setIn(terminalInput1);
         UserIO userIO = new UserIO();
 
-        int readFromInput = userIO.menu();
         System.setIn(terminalInput1); // Fulfills valid order "Mesh chair, 1"
-        userIO.processInput(readFromInput);
+        userIO.processInput(1);
 
-        readFromInput = userIO.menu();
-        userIO.processInput(readFromInput); // Fulfills the valid order
+        userIO.processInput(1); // Fulfills the valid order
         // "Desk lamp, 1"
 
-        readFromInput = userIO.menu();
-        userIO.processInput(readFromInput); // Attempts to fulfill the invalid
+        userIO.processInput(1); // Attempts to fulfill the invalid
         // order "Meaningless order"
 
 
@@ -846,15 +821,14 @@ public class SupplyChainTest {
      */
     @Test public void testUserIO_invalidOrderReadLatestOrderFirstOrder(){
         ByteArrayInputStream terminalInput1 =
-                new ByteArrayInputStream(("1\n" +
+                new ByteArrayInputStream(("\n" +
                                           "Invalid request\n" +
                                           "CANCEL\n").getBytes());
         System.setIn(terminalInput1);
         UserIO userIO = new UserIO();
 
-        int readFromInput = userIO.menu();
-        System.setIn(terminalInput1);
-        userIO.processInput(readFromInput);
+
+        userIO.processInput(1);
 
         assertNull(userIO.getLatestRequest());
     }
@@ -866,26 +840,26 @@ public class SupplyChainTest {
      */
     @Test public void testUserIO_invalidOrderLatestOrderAfterFirst(){
         ByteArrayInputStream terminalInput1 =
-                new ByteArrayInputStream(("1\n" +
+                new ByteArrayInputStream(("\n" +
                                           "Mesh chair, 1\n" +
-                                          "1\n" +
+                                          "\n" +
                                           "Desk lamp, 1\n" +
-                                          "1\n" +
+                                          "\n" +
                                           "Bad bad order\n" +
                                           "CANCEL\n").getBytes());
         System.setIn(terminalInput1);
         UserIO userIO = new UserIO();
 
-        int readFromInput = userIO.menu();
-        System.setIn(terminalInput1); // Fulfills valid order "Mesh chair, 1"
-        userIO.processInput(readFromInput);
 
-        readFromInput = userIO.menu();
-        userIO.processInput(readFromInput); // Fulfills the valid order
+        System.setIn(terminalInput1); // Fulfills valid order "Mesh chair, 1"
+        userIO.processInput(1);
+
+
+        userIO.processInput(1); // Fulfills the valid order
         // "Desk lamp, 1"
 
-        readFromInput = userIO.menu();
-        userIO.processInput(readFromInput); // Attempts to fulfill the invalid
+
+        userIO.processInput(1); // Attempts to fulfill the invalid
         // order "Bad bad order"
 
 
@@ -898,14 +872,12 @@ public class SupplyChainTest {
      * corrected displayed to the terminal.
      */
     @Test public void testUserIO_displaySQLCredentials(){
-        ByteArrayInputStream terminalInput1 = new ByteArrayInputStream(("3"
+        ByteArrayInputStream terminalInput1 = new ByteArrayInputStream(("\n3"
                 + "\n").getBytes());
         System.setIn(terminalInput1);
         UserIO userIO = new UserIO();
 
-        int readFromInput = userIO.menu();
-        System.setIn(terminalInput1);
-        userIO.processInput(readFromInput);
+      userIO.processInput(3);
 
         String expectedOutputREGEX = "(Current database URL: " +
                 "jdbc:mysql://localhost/inventory)" +
@@ -927,14 +899,12 @@ public class SupplyChainTest {
      * displayed to the user in the terminal when requested
      */
     @Test public void testUserIO_displayCurrentOutputFileName(){
-        ByteArrayInputStream terminalInput1 = new ByteArrayInputStream(("2"
+        ByteArrayInputStream terminalInput1 = new ByteArrayInputStream(("\n2"
                 + "\n").getBytes());
         System.setIn(terminalInput1);
         UserIO userIO = new UserIO();
 
-        int readFromInput = userIO.menu();
-        System.setIn(terminalInput1);
-        userIO.processInput(readFromInput);
+      userIO.processInput(2);
 
         String expectedOutputREGEX = "(Current output file name is: " +
                 "OrderOutput.txt)";
@@ -956,22 +926,19 @@ public class SupplyChainTest {
      */
     @Test public void testUserIO_changeOutputFileName(){
         ByteArrayInputStream terminalInput1 =
-                new ByteArrayInputStream(("4\n" +
+                new ByteArrayInputStream(("\n" +
                                           "NewOutputFileName.txt\n" +
                                           "Y\n" +
                                           "2\n").getBytes());
         System.setIn(terminalInput1);
         UserIO userIO = new UserIO();
 
-        int readFromInput = userIO.menu();
 
-        System.setIn(terminalInput1);
-        userIO.processInput(readFromInput); // Processes the input for
+        userIO.processInput(4); // Processes the input for
                                             // requesting to change the
                                             //current output file name
 
-        readFromInput = userIO.menu();
-        userIO.processInput(readFromInput); // Processes the input for
+        userIO.processInput(2); // Processes the input for
                                             // requesting to view the current
                                             // output file name
 
@@ -1003,20 +970,27 @@ public class SupplyChainTest {
      * attempt to access and manipulate data they do not have access to.
      */
 
+
+    /**
+     * testUserIO_QuiteMenu asserts that upon the user entering the value
+     * 0, the method processInput will return false.
+     */
     @Test public void testUserIO_QuitMenu(){
         UserIO ioTest = new UserIO();
         boolean returnedFromIO = ioTest.processInput(0);
         assertFalse(returnedFromIO);
     }
 
+
+    /**
+     * testUserIO_ContinueMenu asserts that when the user puts in a non-zero
+     * value between 1 and 5, processInput will return true.
+     */
     @Test public void testUserIO_ContinueMenu(){
-        ByteArrayInputStream terminalInput
-                = new ByteArrayInputStream(
-                        ("Mesh chair, 1\n"
-                        + "NewOutputFileName.txt\n" +
-                         "Y\n").getBytes());
+        ByteArrayInputStream terminalInput1 =
+                new ByteArrayInputStream(("\n\n\n").getBytes());
+        System.setIn(terminalInput1);
         UserIO testIO = new UserIO();
-        boolean fromOption1 = testIO.processInput(1);
         boolean fromOption2 = testIO.processInput(2);
         boolean fromOption3 = testIO.processInput(3);
         assertTrue(fromOption2 && fromOption3);

--- a/src/edu/ucalgary/ensf409/SupplyChainTest.java
+++ b/src/edu/ucalgary/ensf409/SupplyChainTest.java
@@ -990,4 +990,36 @@ public class SupplyChainTest {
         assertTrue(fileUpdated && correctOutput);
     }
 
+    /**
+     * The alteration of the MySQL credentials cannot be tested reasonably
+     * without knowledge of all other accounts on the system Supply Chain
+     * Manager is being run on because the test may be rendered incorrectly if
+     * the values used for testing to not represent an existing MySQL database
+     * and respective user does not exist on the current machine.
+     *
+     * The choice to have the database credentials' validity tested immediately
+     * after the user has changed them intends to alert the user of a problem
+     * with their current credentials before they continue to program and
+     * attempt to access and manipulate data they do not have access to.
+     */
+
+    @Test public void testUserIO_QuitMenu(){
+        UserIO ioTest = new UserIO();
+        boolean returnedFromIO = ioTest.processInput(0);
+        assertFalse(returnedFromIO);
+    }
+
+    @Test public void testUserIO_ContinueMenu(){
+        ByteArrayInputStream terminalInput
+                = new ByteArrayInputStream(
+                        ("Mesh chair, 1\n"
+                        + "NewOutputFileName.txt\n" +
+                         "Y\n").getBytes());
+        UserIO testIO = new UserIO();
+        boolean fromOption1 = testIO.processInput(1);
+        boolean fromOption2 = testIO.processInput(2);
+        boolean fromOption3 = testIO.processInput(3);
+        assertTrue(fromOption2 && fromOption3);
+    }
+
 }

--- a/src/edu/ucalgary/ensf409/SupplyChainTest.java
+++ b/src/edu/ucalgary/ensf409/SupplyChainTest.java
@@ -10,7 +10,7 @@
  *
  * @since 1.0
  *
- * @version 2.0
+ * @version 2.5
  *
  *
  */
@@ -74,10 +74,11 @@ public class SupplyChainTest {
 
         FileIO fileOutput = new FileIO(manufacturers);
 
-        assertEquals(fileOutput.createUnfulfilledOutput(), ("""
-
-                Order could not be fulfilled based on current inventory.
-                The suggested manufacturer for this order is First manufacturer."""));
+        assertEquals(fileOutput.createUnfulfilledOutput(),
+                ("\n" +
+                 "Order could not be fulfilled based on current inventory.\n" +
+                 "The suggested manufacturer for this order " +
+                 "is First manufacturer."));
     }
 
     /**
@@ -93,10 +94,11 @@ public class SupplyChainTest {
 
         FileIO fileIO = new FileIO(manufacturers);
 
-        assertEquals(fileIO.createUnfulfilledOutput(), ("""
-
-                Order could not be fulfilled based on current inventory.
-                Suggested manufacturers for this order are First manufacturer and Second manufacturer."""));
+        assertEquals(fileIO.createUnfulfilledOutput(),
+                ("\n" +
+                 "Order could not be fulfilled based on current inventory.\n" +
+                 "Suggested manufacturers for this order are First " +
+                 "manufacturer and Second manufacturer."));
     }
 
     /**
@@ -113,10 +115,11 @@ public class SupplyChainTest {
         manufacturers.add("Fourth");
 
         FileIO fileIO = new FileIO(manufacturers);
-        assertEquals(fileIO.createUnfulfilledOutput(), ("""
-
-                Order could not be fulfilled based on current inventory.
-                Suggested manufacturers for this order are First, Second, Third, and Fourth."""));
+        assertEquals(fileIO.createUnfulfilledOutput(),
+                ("\n" +
+                 "Order could not be fulfilled based on current inventory.\n" +
+                 "Suggested manufacturers for this " +
+                 "order are First, Second, Third, and Fourth."));
     }
 
     /**
@@ -601,10 +604,9 @@ public class SupplyChainTest {
      */
     @Test
     public void testUserIO_validOrderReadFurnCategory() {
-        ByteArrayInputStream terminalInput1 = new ByteArrayInputStream(("""
-                1
-                Mesh chair, 1
-                """).getBytes());
+        ByteArrayInputStream terminalInput1 = new ByteArrayInputStream(
+                ("1\n" +
+                 "Mesh chair, 1\n").getBytes());
         System.setIn(terminalInput1);
         UserIO userIO = new UserIO();
 
@@ -623,10 +625,9 @@ public class SupplyChainTest {
      */
     @Test
     public void testUserIO_validOrderReadFurnType() {
-        ByteArrayInputStream terminalInput1 = new ByteArrayInputStream(("""
-                1
-                Mesh chair, 1
-                """).getBytes());
+        ByteArrayInputStream terminalInput1 =
+                new ByteArrayInputStream(("1\n" +
+                                          "Mesh chair, 1\n").getBytes());
         System.setIn(terminalInput1);
         UserIO userIO = new UserIO();
 
@@ -645,10 +646,9 @@ public class SupplyChainTest {
      */
     @Test
     public void testUserIO_validOrderReadNumOfItems() {
-        ByteArrayInputStream terminalInput1 = new ByteArrayInputStream(("""
-                1
-                Mesh chair, 1
-                """).getBytes());
+        ByteArrayInputStream terminalInput1 =
+                new ByteArrayInputStream(("1\n" +
+                                          "Mesh chair, 1\n").getBytes());
         System.setIn(terminalInput1);
         UserIO userIO = new UserIO();
 
@@ -667,10 +667,9 @@ public class SupplyChainTest {
      */
     @Test
     public void testUserIO_validOrderRequest() {
-        ByteArrayInputStream terminalInput1 = new ByteArrayInputStream(("""
-                1
-                Mesh chair, 1
-                """).getBytes());
+        ByteArrayInputStream terminalInput1 =
+                new ByteArrayInputStream(("1\n" +
+                                          "Mesh chair, 1\n").getBytes());
         System.setIn(terminalInput1);
         UserIO userIO = new UserIO();
 
@@ -687,11 +686,10 @@ public class SupplyChainTest {
      * null.
      */
     @Test public void testUserIO_invalidOrderReadFurnTypeFirstOrder(){
-        ByteArrayInputStream terminalInput1 = new ByteArrayInputStream(("""
-                1
-                Invalid input
-                CANCEL
-                """).getBytes());
+        ByteArrayInputStream terminalInput1 =
+                new ByteArrayInputStream(("1\n" +
+                                          "Invalid input\n" +
+                                          "CANCEL\n").getBytes());
         System.setIn(terminalInput1);
         UserIO userIO = new UserIO();
 
@@ -708,15 +706,14 @@ public class SupplyChainTest {
      * will be null.
      */
     @Test public void testUserIO_invalidOrderReadFurnTypeAfterFirst(){
-        ByteArrayInputStream terminalInput1 = new ByteArrayInputStream(("""
-                1
-                Mesh chair, 1
-                1
-                Desk lamp, 1
-                1
-                Invalid order name
-                CANCEL
-                """).getBytes());
+        ByteArrayInputStream terminalInput1 =
+                new ByteArrayInputStream(("1\n" +
+                                          "Mesh chair, 1\n" +
+                                          "1\n" +
+                                          "Desk lamp, 1\n" +
+                                          "1\n" +
+                                          "Invalid order name\n" +
+                                          "CANCEL\n").getBytes());
         System.setIn(terminalInput1);
         UserIO userIO = new UserIO();
 
@@ -742,11 +739,10 @@ public class SupplyChainTest {
      * null.
      */
     @Test public void testUserIO_invalidOrderReadCategoryFirstOrder(){
-        ByteArrayInputStream terminalInput1 = new ByteArrayInputStream(("""
-                1
-                Invalid input
-                CANCEL
-                """).getBytes());
+        ByteArrayInputStream terminalInput1 =
+                new ByteArrayInputStream(("1\n" +
+                                          "Invalid input\n" +
+                                          "CANCEL\n").getBytes());
         System.setIn(terminalInput1);
         UserIO userIO = new UserIO();
 
@@ -763,15 +759,14 @@ public class SupplyChainTest {
      * category will be null.
      */
     @Test public void testUserIO_invalidOrderReadFurnCategoryAfterFirst(){
-        ByteArrayInputStream terminalInput1 = new ByteArrayInputStream(("""
-                1
-                Mesh chair, 1
-                1
-                Desk lamp, 1
-                1
-                Invalid order
-                CANCEL
-                """).getBytes());
+        ByteArrayInputStream terminalInput1 =
+                new ByteArrayInputStream(("1\n" +
+                                          "Mesh chair, 1\n" +
+                                          "1\n" +
+                                          "Desk lamp, 1\n" +
+                                          "1\n" +
+                                          "Invalid order\n" +
+                                          "CANCEL\n").getBytes());
         System.setIn(terminalInput1);
         UserIO userIO = new UserIO();
 
@@ -797,11 +792,10 @@ public class SupplyChainTest {
      * will be null.
      */
     @Test public void testUserIO_invalidOrderReadNumOfItemsFirstOrder(){
-        ByteArrayInputStream terminalInput1 = new ByteArrayInputStream(("""
-                1
-                Bad order
-                CANCEL
-                """).getBytes());
+        ByteArrayInputStream terminalInput1 =
+                new ByteArrayInputStream(("1\n" +
+                                          "Bad order\n" +
+                                          "CANCEL\n").getBytes());
         System.setIn(terminalInput1);
         UserIO userIO = new UserIO();
 
@@ -818,15 +812,14 @@ public class SupplyChainTest {
      * of items will be null.
      */
     @Test public void testUserIO_invalidOrderReadNumOfItemsAfterFirst(){
-        ByteArrayInputStream terminalInput1 = new ByteArrayInputStream(("""
-                1
-                Mesh chair, 1
-                1
-                Desk lamp, 1
-                1
-                Meaningless order
-                CANCEL
-                """).getBytes());
+        ByteArrayInputStream terminalInput1 =
+                new ByteArrayInputStream(("1\n" +
+                                          "Mesh chair, 1\n" +
+                                          "1\n" +
+                                          "Desk lamp, 1\n" +
+                                          "1\n" +
+                                          "Meaningless order\n" +
+                                          "CANCEL\n").getBytes());
         System.setIn(terminalInput1);
         UserIO userIO = new UserIO();
 
@@ -852,11 +845,10 @@ public class SupplyChainTest {
      * latest order will be null.
      */
     @Test public void testUserIO_invalidOrderReadLatestOrderFirstOrder(){
-        ByteArrayInputStream terminalInput1 = new ByteArrayInputStream(("""
-                1
-                Invalid request
-                CANCEL
-                """).getBytes());
+        ByteArrayInputStream terminalInput1 =
+                new ByteArrayInputStream(("1\n" +
+                                          "Invalid request\n" +
+                                          "CANCEL\n").getBytes());
         System.setIn(terminalInput1);
         UserIO userIO = new UserIO();
 
@@ -873,15 +865,14 @@ public class SupplyChainTest {
      * of items will be null.
      */
     @Test public void testUserIO_invalidOrderLatestOrderAfterFirst(){
-        ByteArrayInputStream terminalInput1 = new ByteArrayInputStream(("""
-                1
-                Mesh chair, 1
-                1
-                Desk lamp, 1
-                1
-                Bad bad order
-                CANCEL
-                """).getBytes());
+        ByteArrayInputStream terminalInput1 =
+                new ByteArrayInputStream(("1\n" +
+                                          "Mesh chair, 1\n" +
+                                          "1\n" +
+                                          "Desk lamp, 1\n" +
+                                          "1\n" +
+                                          "Bad bad order\n" +
+                                          "CANCEL\n").getBytes());
         System.setIn(terminalInput1);
         UserIO userIO = new UserIO();
 
@@ -964,12 +955,11 @@ public class SupplyChainTest {
      * on the terminal to the user.
      */
     @Test public void testUserIO_changeOutputFileName(){
-        ByteArrayInputStream terminalInput1 = new ByteArrayInputStream(("""
-                4
-                NewOutputFileName.txt
-                Y
-                2
-                """).getBytes());
+        ByteArrayInputStream terminalInput1 =
+                new ByteArrayInputStream(("4\n" +
+                                          "NewOutputFileName.txt\n" +
+                                          "Y\n" +
+                                          "2\n").getBytes());
         System.setIn(terminalInput1);
         UserIO userIO = new UserIO();
 

--- a/src/edu/ucalgary/ensf409/UserIO.java
+++ b/src/edu/ucalgary/ensf409/UserIO.java
@@ -234,26 +234,75 @@ public class UserIO {
         Matcher requestMatch2 = requestPattern2.matcher(userRequest);
         boolean matchesFound2 = requestMatch2.find();
         if(!matchesFound1 && !matchesFound2){
+            String spellingCapErrREGEX ="([A-Za-z]+[ ]){0,2}" +
+                                         "([A-Za-z]+), ([0-9]+)";
+            Pattern spellingCapErrPat = Pattern.compile(spellingCapErrREGEX);
+            Matcher spelCapErrMat = spellingCapErrPat.matcher(userRequest);
+            boolean spelCapErrMatFound = spelCapErrMat.find();
+            if(!spelCapErrMatFound){
+                System.out.println();
+                System.out.println("Order could not be recognized.");
+            } else if (spelCapErrMat.group(0).length() != (userRequest.length())){
+                System.out.println();
+                System.out.println("Order could not be recognized.");
+            }
+            else {
+                System.out.println();
+                System.out.println("Please make sure that your capitalization");
+                System.out.println("matches that of the provided examples.");
+                System.out.println("Example One: Mesh chair, 3");
+                System.out.println("Example Two: Swing Arm lamp, 1");
+                pressEnterToContinue();
+            }
 
-            System.out.println("Invalid input provided.");
-            System.out.println("Please enter a valid input in the form");
+            System.out.println();
+            System.out.println("Please enter your order in the form");
             System.out.println("[type] [furniture category], " +
                     "[quantity of items]");
             System.out.println("Or enter \"CANCEL\" to return to the menu.\n");
-            System.out.println("Enter request: ");
+            System.out.println("Enter order: ");
             processUserRequest(readLine());
+            return;
         }
+
+
         else{
             if(matchesFound2) {
-                furnType = requestMatch2.group(1);
-                furnCategory = requestMatch2.group(2);
-                numOfItems = requestMatch2.group(3);
-                latestRequest = userRequest;
+                if(requestMatch2.group(0).length()!=userRequest.length()){
+                    System.out.println();
+                    System.out.println("Order could not be recognized.");
+                    System.out.println();
+                    System.out.println("Please enter your order in the form");
+                    System.out.println("[type] [furniture category], " +
+                                       "[quantity of items]");
+                    System.out.println("Or enter \"CANCEL\" to return to the menu.\n");
+                    System.out.println("Enter order: ");
+                    processUserRequest(readLine());
+                    return;
+                } else {
+                    furnType = requestMatch2.group(1);
+                    furnCategory = requestMatch2.group(2);
+                    numOfItems = requestMatch2.group(3);
+                    latestRequest = userRequest;
+                }
             }else{
-                furnType = requestMatch1.group(1);
-                furnCategory = requestMatch1.group(2);
-                numOfItems = requestMatch1.group(3);
-                latestRequest = userRequest;
+                if(matchesFound1 && requestMatch1.group(0).length()!=userRequest.length()){
+                    System.out.println();
+                    System.out.println("Order could not be recognized.");
+                    System.out.println();
+                    System.out.println("Please enter your order in the form");
+                    System.out.println("[type] [furniture category], " +
+                                       "[quantity of items]");
+                    System.out.println("Or enter \"CANCEL\" to return to the menu.\n");
+                    System.out.println("Enter order: ");
+                    processUserRequest(readLine());
+                    return;
+                } else {
+                    furnType = requestMatch1.group(1);
+                    furnCategory = requestMatch1.group(2);
+                    numOfItems = requestMatch1.group(3);
+                    latestRequest = userRequest;
+                }
             }
             if(furnCategory.equals("chair") || furnCategory.equals("desk")
                     || furnCategory.equals("filing")
@@ -274,16 +323,41 @@ public class UserIO {
                                 .suggestedManufacturers(furnCategory));
                     }
                 } else {
-                    System.out.println("Invalid type: " + furnType + ", try again.");
+                    System.out.println();
+                    System.out.println("The furniture type " + furnType  +
+                                       "could ");
+                    System.out.println("not be found in the " +
+                                       "current database.");
+                    pressEnterToContinue();
+                    System.out.println();
+                    System.out.println("Please enter your order in the form");
+                    System.out.println("[type] [furniture category], " +
+                                       "[quantity of items]");
+                    System.out.println("Or enter \"CANCEL\" to return to the menu.\n");
+                    System.out.println("Enter order: ");
                     processUserRequest(readLine());
+                    return;
                 }
             } else {
-                System.out.println("Invalid category, try again.");
+                System.out.println();
+                System.out.println("The category " + furnCategory  +
+                                   "could ");
+                System.out.println("not be found in the " +
+                                   "current database.");
+                pressEnterToContinue();
+                System.out.println();
+                System.out.println("Please enter your order in the form");
+                System.out.println("[type] [furniture category], " +
+                                   "[quantity of items]");
+                System.out.println("Or enter \"CANCEL\" to return to the menu.\n");
+                System.out.println("Enter order: ");
                 processUserRequest(readLine());
+                return;
             }
 
 
         }
+        return;
     }
 
     /**

--- a/src/edu/ucalgary/ensf409/UserIO.java
+++ b/src/edu/ucalgary/ensf409/UserIO.java
@@ -162,6 +162,7 @@ public class UserIO {
             case 2:
                 System.out.println("\nCurrent output file name is: " +
                         outputFile + "\n");
+                readLine();
                 return true;
             case 3:
                 System.out.println("\nCurrent database URL: "
@@ -170,6 +171,7 @@ public class UserIO {
                         + databaseIO.getUsername());
                 System.out.println("Current database password: "
                         + hidePassword(databaseIO.getPassword()));
+                readLine();
                 return true;
             case 4:
                 readLine();
@@ -452,7 +454,7 @@ public class UserIO {
             else {
                 databaseIO.updateCredentials(newURL, newUser, newPassword);
                 System.out.println("\nMySQL credentials have been " +
-                        "\nupdated successfully.");
+                        "\nupdated.");
                 System.out.println("Returning to menu.");
                 return;
 

--- a/src/edu/ucalgary/ensf409/UserIO.java
+++ b/src/edu/ucalgary/ensf409/UserIO.java
@@ -32,6 +32,7 @@ public class UserIO {
      * @return int corresponding to the selected option by the user
      */
     public int menu() {
+            pressEnterToContinue();
             System.out.println();
             System.out.println("1. Input a User Request");
             System.out.println("2. View Current Output Filename");
@@ -43,6 +44,22 @@ public class UserIO {
             System.out.print("Enter your selection: ");
             return readIntUntilAccepted(0, 5);
     }
+
+    /**
+     * Method for loading the introduction to the program, before
+     * giving the user the option to pick through the menu.
+     * giving the user the option to pick through the menu.
+     */
+    public void firstMenu(){
+        System.out.println();
+        System.out.println("Welcome to the Supply Chain Manager for");
+        System.out.println("recycled and second hand furniture.");
+        System.out.println();
+        System.out.println("Press ENTER after every prompted entry ");
+        System.out.println("and type \"CANCEL\" in any operation ");
+        System.out.println("to return to the main menu.");
+    }
+
 
 
     /**
@@ -127,7 +144,7 @@ public class UserIO {
      * if the user inputs an invalid input.
      * @param inputValue Request from the user.
      */
-    public void processInput(int inputValue){
+    public boolean processInput(int inputValue){
         switch(inputValue){
             case 1:
                 setReadValuesNull();
@@ -141,11 +158,11 @@ public class UserIO {
                 System.out.println("Enter request: ");
                 String readFromScan = readLine();
                 processUserRequest(readFromScan);
-                break;
+                return true;
             case 2:
                 System.out.println("\nCurrent output file name is: " +
                         outputFile + "\n");
-                break;
+                return true;
             case 3:
                 System.out.println("\nCurrent database URL: "
                         + databaseIO.getDbUrl());
@@ -153,7 +170,7 @@ public class UserIO {
                         + databaseIO.getUsername());
                 System.out.println("Current database password: "
                         + hidePassword(databaseIO.getPassword()));
-                break;
+                return true;
             case 4:
                 readLine();
                 System.out.println("\nThe current output file name is: \"" +
@@ -163,16 +180,18 @@ public class UserIO {
                     System.out.println("New file name: ");
                     String readFileName = readLine();
                 updateOutputName(readFileName);
-                break;
+                return true;
             case 5:
                 updateSQLCredentials();
-                break;
+                return true;
             case 0:
-                System.out.println("\nSelected option 0. Now closing program.");
-                input.close();
-                System.exit(0);
+                System.out.println();
+                System.out.println("Thank you for using Supply Chain Manager.");
+                System.out.println("Now closing the program.");
+                return false;
 
         }
+        return true;
     }
 
     /**
@@ -505,6 +524,29 @@ public class UserIO {
     public void close() {
         input.close();
     }
+
+
+    /**
+     * Method for creating a space in terminal for the user to press enter
+     * before continuing the program.
+     * Intended to allow the user a chance to look at the loaded data
+     * before the menu is loaded again and moving the information away
+     * from the user's focus.
+     */
+    private void pressEnterToContinue(){
+        boolean pressed = false;
+        String returned = null;
+        while(!pressed) {
+            System.out.println();
+            System.out.println("Press ENTER to continue");
+            returned = readLine();
+            if (returned != null) {
+                pressed = true;
+            }
+        }
+    }
+
+
 
     /**
      * Private method setReadValuesNull sets the values for

--- a/src/edu/ucalgary/ensf409/UserIO.java
+++ b/src/edu/ucalgary/ensf409/UserIO.java
@@ -160,8 +160,8 @@ public class UserIO {
                         outputFile + "\"\n");
                 System.out.println("Please the filename for order output, or " +
                         "enter \"CANCEL\" to cancel the operation.");
-                System.out.println("New file name: ");
-                String readFileName = readLine();
+                    System.out.println("New file name: ");
+                    String readFileName = readLine();
                 updateOutputName(readFileName);
                 break;
             case 5:


### PR DESCRIPTION
Corrected:
 - All compilation errors due to attempts at syntax beyond JavaSE11
 - Removed the bug that caused a fulfilled order that was preceded with several failed orders to print multiple times

Added:
- Rudimentary spelling and capitalization check for user input to order request. Was more specific about what the user needed to correct for the order to be valid
- A "Press enter to continue" method, which allows for the program to stop until the user presses enter - thus giving them time to look at the information in front of them before continuing with the program and pulling up the menu
- A "First menu" that gives a program introduction before launching the rest of the program
- Tests for checking that the method processInput returns the correct value. 

Altered:
- processInput method now returns a boolean that is used to keep the while loop in the main method running. Upon the user selection of  0 for the menu, processInput returns false and the while loop in main will stop.
-  main method is now the only where System.exit(0) is located, to be called after the user opts to close the program via the main menu. 